### PR TITLE
feature: expose from/to params

### DIFF
--- a/lib/src/animations/animate_do_attention_seekers.dart
+++ b/lib/src/animations/animate_do_attention_seekers.dart
@@ -248,20 +248,26 @@ class Pulse extends StatefulWidget {
   final bool manualTrigger;
   final bool animate;
   final Function(AnimateDoDirection direction)? onFinish;
-  final Curve curve;
+  final Curve curveIn;
+  final Curve curveOut;
+  final double from;
+  final double to;
 
-  Pulse(
-      {key,
-      required this.child,
-      this.duration = const Duration(milliseconds: 1000),
-      this.delay = const Duration(milliseconds: 0),
-      this.infinite = false,
-      this.controller,
-      this.manualTrigger = false,
-      this.animate = true,
-      this.onFinish,
-      this.curve = Curves.easeOut})
-      : super(key: key) {
+  Pulse({
+    required this.child,
+    this.duration = const Duration(milliseconds: 1000),
+    this.delay = const Duration(milliseconds: 0),
+    this.infinite = false,
+    this.controller,
+    this.manualTrigger = false,
+    this.animate = true,
+    this.onFinish,
+    this.curveIn = Curves.easeOut,
+    this.curveOut = Curves.easeIn,
+    this.from = 1,
+    this.to = 1.05, // original value: 1.5
+    super.key,
+  }) {
     if (manualTrigger == true && controller == null) {
       throw FlutterError('If you want to use manualTrigger:true, \n\n'
           'Then you must provide the controller property, that is a callback like:\n\n'
@@ -291,13 +297,15 @@ class PulseState extends State<Pulse>
 
     controller = AnimationController(duration: widget.duration, vsync: this);
 
-    animationInc = Tween<double>(begin: 1, end: 1.5).animate(CurvedAnimation(
-        parent: controller,
-        curve: Interval(0, 0.5, curve: widget.curve))); // Curves.easeOut
+    animationInc = Tween<double>(begin: widget.from, end: widget.to).animate(
+        CurvedAnimation(
+            parent: controller,
+            curve: Interval(0, 0.2, curve: widget.curveIn))); // Curves.easeOut
 
-    animationDec = Tween<double>(begin: 1.5, end: 1).animate(CurvedAnimation(
-        parent: controller,
-        curve: Interval(0.5, 1, curve: widget.curve))); // Curves.easeIn
+    animationDec = Tween<double>(begin: widget.to, end: widget.from).animate(
+        CurvedAnimation(
+            parent: controller,
+            curve: Interval(0.2, 1, curve: widget.curveOut))); // Curves.easeIn
 
     /// Provided by the mixing [AnimateDoState] class
     configAnimation(


### PR DESCRIPTION
This PR exposes new from and to values for the Pulse attention seeker animation. This allows controlling the begin and end value of the tween.

This change is not a breaking and in addition, it does not change any current behaviour as the default values remain equal to the previous constant values.


I create the Pull Request from the one created by 'flodaniel' on Nov 24, 2022